### PR TITLE
Allow plugins to reserve nodes for their exclusive use

### DIFF
--- a/docs/src/changelog.dj
+++ b/docs/src/changelog.dj
@@ -7,6 +7,8 @@ order: -1
 ## 0.2 (unreleased)
 
 - [Typedoc integration](#typedoc-integration)
+- Plugin API improvements
+- OpenGraph and Twitter Card metadata
 
 ## 0.1
 

--- a/docs/src/features/gfm.md
+++ b/docs/src/features/gfm.md
@@ -6,8 +6,6 @@ md_flavor: gfm
 
 ## Alerts
 
-### H3
-
 ```md
 > [!NOTE]
 > Useful information that users should know, even when skimming content.

--- a/docs/src/typescript_link_mapping.json
+++ b/docs/src/typescript_link_mapping.json
@@ -8,258 +8,615 @@
   "linkMappings": [
     {
       "linkDestination": "DocSet",
-      "relativeURL": "classes/DocSet.html",
-      "defaultLabel": "DocSet"
+      "relativeURL": "classes/DocSet.html"
     },
     {
       "linkDestination": "DocSet.constructor",
-      "relativeURL": "classes/DocSet.html#constructor",
-      "defaultLabel": "constructor"
+      "relativeURL": "classes/DocSet.html#constructor"
     },
     {
       "linkDestination": "DocSet.config",
-      "relativeURL": "classes/DocSet.html#config",
-      "defaultLabel": "config"
+      "relativeURL": "classes/DocSet.html#config"
     },
     {
       "linkDestination": "config",
-      "relativeURL": "classes/DocSet.html#config",
-      "defaultLabel": "config"
+      "relativeURL": "classes/DocSet.html#config"
     },
     {
       "linkDestination": "DocSet.docs",
-      "relativeURL": "classes/DocSet.html#docs",
-      "defaultLabel": "docs"
+      "relativeURL": "classes/DocSet.html#docs"
     },
     {
       "linkDestination": "docs",
-      "relativeURL": "classes/DocSet.html#docs",
-      "defaultLabel": "docs"
+      "relativeURL": "classes/DocSet.html#docs"
     },
     {
       "linkDestination": "DocSet.plugins",
-      "relativeURL": "classes/DocSet.html#plugins",
-      "defaultLabel": "plugins"
+      "relativeURL": "classes/DocSet.html#plugins"
     },
     {
       "linkDestination": "plugins",
-      "relativeURL": "classes/DocSet.html#plugins",
-      "defaultLabel": "plugins"
+      "relativeURL": "classes/DocSet.html#plugins"
     },
     {
       "linkDestination": "DocSet.tree",
-      "relativeURL": "classes/DocSet.html#tree",
-      "defaultLabel": "tree"
+      "relativeURL": "classes/DocSet.html#tree"
     },
     {
       "linkDestination": "tree",
-      "relativeURL": "classes/DocSet.html#tree",
-      "defaultLabel": "tree"
+      "relativeURL": "classes/DocSet.html#tree"
     },
     {
       "linkDestination": "DocSet.getDoc",
-      "relativeURL": "classes/DocSet.html#getDoc",
-      "defaultLabel": "getDoc"
+      "relativeURL": "classes/DocSet.html#getDoc"
     },
     {
       "linkDestination": "getDoc",
-      "relativeURL": "classes/DocSet.html#getDoc",
-      "defaultLabel": "getDoc"
+      "relativeURL": "classes/DocSet.html#getDoc"
     },
     {
       "linkDestination": "DocSet.makeRenderableCopy",
-      "relativeURL": "classes/DocSet.html#makeRenderableCopy",
-      "defaultLabel": "makeRenderableCopy"
+      "relativeURL": "classes/DocSet.html#makeRenderableCopy"
     },
     {
       "linkDestination": "makeRenderableCopy",
-      "relativeURL": "classes/DocSet.html#makeRenderableCopy",
-      "defaultLabel": "makeRenderableCopy"
+      "relativeURL": "classes/DocSet.html#makeRenderableCopy"
     },
     {
       "linkDestination": "DocSet.runPasses",
-      "relativeURL": "classes/DocSet.html#runPasses",
-      "defaultLabel": "runPasses"
+      "relativeURL": "classes/DocSet.html#runPasses"
     },
     {
       "linkDestination": "runPasses",
-      "relativeURL": "classes/DocSet.html#runPasses",
-      "defaultLabel": "runPasses"
+      "relativeURL": "classes/DocSet.html#runPasses"
     },
     {
       "linkDestination": "LogCollector",
-      "relativeURL": "classes/LogCollector.html",
-      "defaultLabel": "LogCollector"
+      "relativeURL": "classes/LogCollector.html"
     },
     {
       "linkDestination": "LogCollector.constructor",
-      "relativeURL": "classes/LogCollector.html#constructor",
-      "defaultLabel": "constructor"
+      "relativeURL": "classes/LogCollector.html#constructor"
     },
     {
       "linkDestination": "LogCollector.label",
-      "relativeURL": "classes/LogCollector.html#label",
-      "defaultLabel": "label"
+      "relativeURL": "classes/LogCollector.html#label"
     },
     {
       "linkDestination": "label",
-      "relativeURL": "classes/LogCollector.html#label",
-      "defaultLabel": "label"
+      "relativeURL": "classes/LogCollector.html#label"
     },
     {
       "linkDestination": "LogCollector.lines",
-      "relativeURL": "classes/LogCollector.html#lines",
-      "defaultLabel": "lines"
+      "relativeURL": "classes/LogCollector.html#lines"
     },
     {
       "linkDestination": "lines",
-      "relativeURL": "classes/LogCollector.html#lines",
-      "defaultLabel": "lines"
+      "relativeURL": "classes/LogCollector.html#lines"
     },
     {
       "linkDestination": "LogCollector.loader",
-      "relativeURL": "classes/LogCollector.html#loader",
-      "defaultLabel": "loader"
+      "relativeURL": "classes/LogCollector.html#loader"
     },
     {
       "linkDestination": "loader",
-      "relativeURL": "classes/LogCollector.html#loader",
-      "defaultLabel": "loader"
+      "relativeURL": "classes/LogCollector.html#loader"
     },
     {
       "linkDestination": "LogCollector.debug",
-      "relativeURL": "classes/LogCollector.html#debug",
-      "defaultLabel": "debug"
+      "relativeURL": "classes/LogCollector.html#debug"
     },
     {
       "linkDestination": "debug",
-      "relativeURL": "classes/LogCollector.html#debug",
-      "defaultLabel": "debug"
+      "relativeURL": "classes/LogCollector.html#debug"
     },
     {
       "linkDestination": "LogCollector.dump",
-      "relativeURL": "classes/LogCollector.html#dump",
-      "defaultLabel": "dump"
+      "relativeURL": "classes/LogCollector.html#dump"
     },
     {
       "linkDestination": "dump",
-      "relativeURL": "classes/LogCollector.html#dump",
-      "defaultLabel": "dump"
+      "relativeURL": "classes/LogCollector.html#dump"
     },
     {
       "linkDestination": "LogCollector.error",
-      "relativeURL": "classes/LogCollector.html#error",
-      "defaultLabel": "error"
+      "relativeURL": "classes/LogCollector.html#error"
     },
     {
       "linkDestination": "error",
-      "relativeURL": "classes/LogCollector.html#error",
-      "defaultLabel": "error"
+      "relativeURL": "classes/LogCollector.html#error"
     },
     {
       "linkDestination": "LogCollector.fail",
-      "relativeURL": "classes/LogCollector.html#fail",
-      "defaultLabel": "fail"
+      "relativeURL": "classes/LogCollector.html#fail"
     },
     {
       "linkDestination": "fail",
-      "relativeURL": "classes/LogCollector.html#fail",
-      "defaultLabel": "fail"
+      "relativeURL": "classes/LogCollector.html#fail"
     },
     {
       "linkDestination": "LogCollector.info",
-      "relativeURL": "classes/LogCollector.html#info",
-      "defaultLabel": "info"
+      "relativeURL": "classes/LogCollector.html#info"
     },
     {
       "linkDestination": "info",
-      "relativeURL": "classes/LogCollector.html#info",
-      "defaultLabel": "info"
+      "relativeURL": "classes/LogCollector.html#info"
     },
     {
       "linkDestination": "LogCollector.succeed",
-      "relativeURL": "classes/LogCollector.html#succeed",
-      "defaultLabel": "succeed"
+      "relativeURL": "classes/LogCollector.html#succeed"
     },
     {
       "linkDestination": "succeed",
-      "relativeURL": "classes/LogCollector.html#succeed",
-      "defaultLabel": "succeed"
+      "relativeURL": "classes/LogCollector.html#succeed"
     },
     {
       "linkDestination": "LogCollector.warning",
-      "relativeURL": "classes/LogCollector.html#warning",
-      "defaultLabel": "warning"
+      "relativeURL": "classes/LogCollector.html#warning"
     },
     {
       "linkDestination": "warning",
-      "relativeURL": "classes/LogCollector.html#warning",
-      "defaultLabel": "warning"
+      "relativeURL": "classes/LogCollector.html#warning"
     },
     {
       "linkDestination": "DjockeyConfig",
-      "relativeURL": "types/DjockeyConfig.html",
-      "defaultLabel": "DjockeyConfig"
+      "relativeURL": "types/DjockeyConfig.html"
     },
     {
       "linkDestination": "DjockeyConfigResolved",
-      "relativeURL": "types/DjockeyConfigResolved.html",
-      "defaultLabel": "DjockeyConfigResolved"
+      "relativeURL": "types/DjockeyConfigResolved.html"
     },
     {
       "linkDestination": "DjockeyDoc",
-      "relativeURL": "types/DjockeyDoc.html",
-      "defaultLabel": "DjockeyDoc"
+      "relativeURL": "types/DjockeyDoc.html"
     },
     {
       "linkDestination": "DjockeyInputFormat",
-      "relativeURL": "types/DjockeyInputFormat.html",
-      "defaultLabel": "DjockeyInputFormat"
+      "relativeURL": "types/DjockeyInputFormat.html"
     },
     {
       "linkDestination": "DjockeyLinkMapping",
-      "relativeURL": "types/DjockeyLinkMapping.html",
-      "defaultLabel": "DjockeyLinkMapping"
+      "relativeURL": "types/DjockeyLinkMapping.html"
     },
     {
       "linkDestination": "DjockeyLinkMappingDoc",
-      "relativeURL": "types/DjockeyLinkMappingDoc.html",
-      "defaultLabel": "DjockeyLinkMappingDoc"
+      "relativeURL": "types/DjockeyLinkMappingDoc.html"
     },
     {
       "linkDestination": "DjockeyOutputFormat",
-      "relativeURL": "types/DjockeyOutputFormat.html",
-      "defaultLabel": "DjockeyOutputFormat"
+      "relativeURL": "types/DjockeyOutputFormat.html"
     },
     {
       "linkDestination": "DjockeyPlugin",
-      "relativeURL": "types/DjockeyPlugin.html",
-      "defaultLabel": "DjockeyPlugin"
+      "relativeURL": "types/DjockeyPlugin.html"
     },
     {
       "linkDestination": "DjockeyPluginModule",
-      "relativeURL": "types/DjockeyPluginModule.html",
-      "defaultLabel": "DjockeyPluginModule"
+      "relativeURL": "types/DjockeyPluginModule.html"
     },
     {
       "linkDestination": "DjockeyRenderer",
-      "relativeURL": "types/DjockeyRenderer.html",
-      "defaultLabel": "DjockeyRenderer"
+      "relativeURL": "types/DjockeyRenderer.html"
     },
     {
       "linkDestination": "DocTree",
-      "relativeURL": "types/DocTree.html",
-      "defaultLabel": "DocTree"
+      "relativeURL": "types/DocTree.html"
     },
     {
       "linkDestination": "DocTreeSection",
-      "relativeURL": "types/DocTreeSection.html",
-      "defaultLabel": "DocTreeSection"
+      "relativeURL": "types/DocTreeSection.html"
     },
     {
       "linkDestination": "applyFilter",
-      "relativeURL": "functions/applyFilter.html",
-      "defaultLabel": "applyFilter"
+      "relativeURL": "functions/applyFilter.html"
+    },
+    {
+      "linkDestination": "DocSet",
+      "relativeURL": "classes/DocSet.html"
+    },
+    {
+      "linkDestination": "DocSet.constructor",
+      "relativeURL": "classes/DocSet.html#constructor"
+    },
+    {
+      "linkDestination": "DocSet.config",
+      "relativeURL": "classes/DocSet.html#config"
+    },
+    {
+      "linkDestination": "config",
+      "relativeURL": "classes/DocSet.html#config"
+    },
+    {
+      "linkDestination": "DocSet.docs",
+      "relativeURL": "classes/DocSet.html#docs"
+    },
+    {
+      "linkDestination": "docs",
+      "relativeURL": "classes/DocSet.html#docs"
+    },
+    {
+      "linkDestination": "DocSet.plugins",
+      "relativeURL": "classes/DocSet.html#plugins"
+    },
+    {
+      "linkDestination": "plugins",
+      "relativeURL": "classes/DocSet.html#plugins"
+    },
+    {
+      "linkDestination": "DocSet.tree",
+      "relativeURL": "classes/DocSet.html#tree"
+    },
+    {
+      "linkDestination": "tree",
+      "relativeURL": "classes/DocSet.html#tree"
+    },
+    {
+      "linkDestination": "DocSet.getDoc",
+      "relativeURL": "classes/DocSet.html#getDoc"
+    },
+    {
+      "linkDestination": "getDoc",
+      "relativeURL": "classes/DocSet.html#getDoc"
+    },
+    {
+      "linkDestination": "DocSet.makeRenderableCopy",
+      "relativeURL": "classes/DocSet.html#makeRenderableCopy"
+    },
+    {
+      "linkDestination": "makeRenderableCopy",
+      "relativeURL": "classes/DocSet.html#makeRenderableCopy"
+    },
+    {
+      "linkDestination": "DocSet.runPasses",
+      "relativeURL": "classes/DocSet.html#runPasses"
+    },
+    {
+      "linkDestination": "runPasses",
+      "relativeURL": "classes/DocSet.html#runPasses"
+    },
+    {
+      "linkDestination": "LogCollector",
+      "relativeURL": "classes/LogCollector.html"
+    },
+    {
+      "linkDestination": "LogCollector.constructor",
+      "relativeURL": "classes/LogCollector.html#constructor"
+    },
+    {
+      "linkDestination": "LogCollector.label",
+      "relativeURL": "classes/LogCollector.html#label"
+    },
+    {
+      "linkDestination": "label",
+      "relativeURL": "classes/LogCollector.html#label"
+    },
+    {
+      "linkDestination": "LogCollector.lines",
+      "relativeURL": "classes/LogCollector.html#lines"
+    },
+    {
+      "linkDestination": "lines",
+      "relativeURL": "classes/LogCollector.html#lines"
+    },
+    {
+      "linkDestination": "LogCollector.loader",
+      "relativeURL": "classes/LogCollector.html#loader"
+    },
+    {
+      "linkDestination": "loader",
+      "relativeURL": "classes/LogCollector.html#loader"
+    },
+    {
+      "linkDestination": "LogCollector.debug",
+      "relativeURL": "classes/LogCollector.html#debug"
+    },
+    {
+      "linkDestination": "debug",
+      "relativeURL": "classes/LogCollector.html#debug"
+    },
+    {
+      "linkDestination": "LogCollector.dump",
+      "relativeURL": "classes/LogCollector.html#dump"
+    },
+    {
+      "linkDestination": "dump",
+      "relativeURL": "classes/LogCollector.html#dump"
+    },
+    {
+      "linkDestination": "LogCollector.error",
+      "relativeURL": "classes/LogCollector.html#error"
+    },
+    {
+      "linkDestination": "error",
+      "relativeURL": "classes/LogCollector.html#error"
+    },
+    {
+      "linkDestination": "LogCollector.fail",
+      "relativeURL": "classes/LogCollector.html#fail"
+    },
+    {
+      "linkDestination": "fail",
+      "relativeURL": "classes/LogCollector.html#fail"
+    },
+    {
+      "linkDestination": "LogCollector.info",
+      "relativeURL": "classes/LogCollector.html#info"
+    },
+    {
+      "linkDestination": "info",
+      "relativeURL": "classes/LogCollector.html#info"
+    },
+    {
+      "linkDestination": "LogCollector.succeed",
+      "relativeURL": "classes/LogCollector.html#succeed"
+    },
+    {
+      "linkDestination": "succeed",
+      "relativeURL": "classes/LogCollector.html#succeed"
+    },
+    {
+      "linkDestination": "LogCollector.warning",
+      "relativeURL": "classes/LogCollector.html#warning"
+    },
+    {
+      "linkDestination": "warning",
+      "relativeURL": "classes/LogCollector.html#warning"
+    },
+    {
+      "linkDestination": "DjockeyConfig",
+      "relativeURL": "types/DjockeyConfig.html"
+    },
+    {
+      "linkDestination": "DjockeyConfigResolved",
+      "relativeURL": "types/DjockeyConfigResolved.html"
+    },
+    {
+      "linkDestination": "DjockeyDoc",
+      "relativeURL": "types/DjockeyDoc.html"
+    },
+    {
+      "linkDestination": "DjockeyInputFormat",
+      "relativeURL": "types/DjockeyInputFormat.html"
+    },
+    {
+      "linkDestination": "DjockeyLinkMapping",
+      "relativeURL": "types/DjockeyLinkMapping.html"
+    },
+    {
+      "linkDestination": "DjockeyLinkMappingDoc",
+      "relativeURL": "types/DjockeyLinkMappingDoc.html"
+    },
+    {
+      "linkDestination": "DjockeyOutputFormat",
+      "relativeURL": "types/DjockeyOutputFormat.html"
+    },
+    {
+      "linkDestination": "DjockeyPlugin",
+      "relativeURL": "types/DjockeyPlugin.html"
+    },
+    {
+      "linkDestination": "DjockeyPluginModule",
+      "relativeURL": "types/DjockeyPluginModule.html"
+    },
+    {
+      "linkDestination": "DjockeyRenderer",
+      "relativeURL": "types/DjockeyRenderer.html"
+    },
+    {
+      "linkDestination": "DocTree",
+      "relativeURL": "types/DocTree.html"
+    },
+    {
+      "linkDestination": "DocTreeSection",
+      "relativeURL": "types/DocTreeSection.html"
+    },
+    {
+      "linkDestination": "applyFilter",
+      "relativeURL": "functions/applyFilter.html"
+    },
+    {
+      "linkDestination": "DocSet",
+      "relativeURL": "classes/DocSet.html"
+    },
+    {
+      "linkDestination": "DocSet.constructor",
+      "relativeURL": "classes/DocSet.html#constructor"
+    },
+    {
+      "linkDestination": "DocSet.config",
+      "relativeURL": "classes/DocSet.html#config"
+    },
+    {
+      "linkDestination": "config",
+      "relativeURL": "classes/DocSet.html#config"
+    },
+    {
+      "linkDestination": "DocSet.docs",
+      "relativeURL": "classes/DocSet.html#docs"
+    },
+    {
+      "linkDestination": "docs",
+      "relativeURL": "classes/DocSet.html#docs"
+    },
+    {
+      "linkDestination": "DocSet.plugins",
+      "relativeURL": "classes/DocSet.html#plugins"
+    },
+    {
+      "linkDestination": "plugins",
+      "relativeURL": "classes/DocSet.html#plugins"
+    },
+    {
+      "linkDestination": "DocSet.tree",
+      "relativeURL": "classes/DocSet.html#tree"
+    },
+    {
+      "linkDestination": "tree",
+      "relativeURL": "classes/DocSet.html#tree"
+    },
+    {
+      "linkDestination": "DocSet.getDoc",
+      "relativeURL": "classes/DocSet.html#getDoc"
+    },
+    {
+      "linkDestination": "getDoc",
+      "relativeURL": "classes/DocSet.html#getDoc"
+    },
+    {
+      "linkDestination": "DocSet.makeRenderableCopy",
+      "relativeURL": "classes/DocSet.html#makeRenderableCopy"
+    },
+    {
+      "linkDestination": "makeRenderableCopy",
+      "relativeURL": "classes/DocSet.html#makeRenderableCopy"
+    },
+    {
+      "linkDestination": "DocSet.runPasses",
+      "relativeURL": "classes/DocSet.html#runPasses"
+    },
+    {
+      "linkDestination": "runPasses",
+      "relativeURL": "classes/DocSet.html#runPasses"
+    },
+    {
+      "linkDestination": "LogCollector",
+      "relativeURL": "classes/LogCollector.html"
+    },
+    {
+      "linkDestination": "LogCollector.constructor",
+      "relativeURL": "classes/LogCollector.html#constructor"
+    },
+    {
+      "linkDestination": "LogCollector.label",
+      "relativeURL": "classes/LogCollector.html#label"
+    },
+    {
+      "linkDestination": "label",
+      "relativeURL": "classes/LogCollector.html#label"
+    },
+    {
+      "linkDestination": "LogCollector.lines",
+      "relativeURL": "classes/LogCollector.html#lines"
+    },
+    {
+      "linkDestination": "lines",
+      "relativeURL": "classes/LogCollector.html#lines"
+    },
+    {
+      "linkDestination": "LogCollector.loader",
+      "relativeURL": "classes/LogCollector.html#loader"
+    },
+    {
+      "linkDestination": "loader",
+      "relativeURL": "classes/LogCollector.html#loader"
+    },
+    {
+      "linkDestination": "LogCollector.debug",
+      "relativeURL": "classes/LogCollector.html#debug"
+    },
+    {
+      "linkDestination": "debug",
+      "relativeURL": "classes/LogCollector.html#debug"
+    },
+    {
+      "linkDestination": "LogCollector.dump",
+      "relativeURL": "classes/LogCollector.html#dump"
+    },
+    {
+      "linkDestination": "dump",
+      "relativeURL": "classes/LogCollector.html#dump"
+    },
+    {
+      "linkDestination": "LogCollector.error",
+      "relativeURL": "classes/LogCollector.html#error"
+    },
+    {
+      "linkDestination": "error",
+      "relativeURL": "classes/LogCollector.html#error"
+    },
+    {
+      "linkDestination": "LogCollector.fail",
+      "relativeURL": "classes/LogCollector.html#fail"
+    },
+    {
+      "linkDestination": "fail",
+      "relativeURL": "classes/LogCollector.html#fail"
+    },
+    {
+      "linkDestination": "LogCollector.info",
+      "relativeURL": "classes/LogCollector.html#info"
+    },
+    {
+      "linkDestination": "info",
+      "relativeURL": "classes/LogCollector.html#info"
+    },
+    {
+      "linkDestination": "LogCollector.succeed",
+      "relativeURL": "classes/LogCollector.html#succeed"
+    },
+    {
+      "linkDestination": "succeed",
+      "relativeURL": "classes/LogCollector.html#succeed"
+    },
+    {
+      "linkDestination": "LogCollector.warning",
+      "relativeURL": "classes/LogCollector.html#warning"
+    },
+    {
+      "linkDestination": "warning",
+      "relativeURL": "classes/LogCollector.html#warning"
+    },
+    {
+      "linkDestination": "DjockeyConfig",
+      "relativeURL": "types/DjockeyConfig.html"
+    },
+    {
+      "linkDestination": "DjockeyConfigResolved",
+      "relativeURL": "types/DjockeyConfigResolved.html"
+    },
+    {
+      "linkDestination": "DjockeyDoc",
+      "relativeURL": "types/DjockeyDoc.html"
+    },
+    {
+      "linkDestination": "DjockeyInputFormat",
+      "relativeURL": "types/DjockeyInputFormat.html"
+    },
+    {
+      "linkDestination": "DjockeyLinkMapping",
+      "relativeURL": "types/DjockeyLinkMapping.html"
+    },
+    {
+      "linkDestination": "DjockeyLinkMappingDoc",
+      "relativeURL": "types/DjockeyLinkMappingDoc.html"
+    },
+    {
+      "linkDestination": "DjockeyOutputFormat",
+      "relativeURL": "types/DjockeyOutputFormat.html"
+    },
+    {
+      "linkDestination": "DjockeyPlugin",
+      "relativeURL": "types/DjockeyPlugin.html"
+    },
+    {
+      "linkDestination": "DjockeyPluginModule",
+      "relativeURL": "types/DjockeyPluginModule.html"
+    },
+    {
+      "linkDestination": "DjockeyRenderer",
+      "relativeURL": "types/DjockeyRenderer.html"
+    },
+    {
+      "linkDestination": "DocTree",
+      "relativeURL": "types/DocTree.html"
+    },
+    {
+      "linkDestination": "DocTreeSection",
+      "relativeURL": "types/DocTreeSection.html"
+    },
+    {
+      "linkDestination": "applyFilter",
+      "relativeURL": "functions/applyFilter.html"
     }
   ]
 }

--- a/src/engine/builtinPlugins.ts
+++ b/src/engine/builtinPlugins.ts
@@ -3,6 +3,7 @@ import { DjotDemoPlugin } from "../plugins/djotDemoPlugin.js";
 import { GFMAlertsPlugin } from "../plugins/gfmAlertsPlugin.js";
 import { IndextermsPlugin } from "../plugins/indextermsPlugin.js";
 import { LinkRewritingPlugin } from "../plugins/linkRewritingPlugin.js";
+import { MermaidPlugin } from "../plugins/mermaidPlugin.js";
 import { SyntaxHighlightingPlugin } from "../plugins/syntaxHighlighting.js";
 import { TabGroupPlugin } from "../plugins/tabGroupPlugin.js";
 import { TableOfContentsPlugin } from "../plugins/tableOfContentsPlugin.js";
@@ -13,6 +14,7 @@ export function makeBuiltinPlugins(
   config: DjockeyConfigResolved
 ): DjockeyPlugin[] {
   return [
+    new MermaidPlugin(),
     new TabGroupPlugin(),
     new TableOfContentsPlugin(),
     new IndextermsPlugin(),

--- a/src/engine/docset.ts
+++ b/src/engine/docset.ts
@@ -1,20 +1,40 @@
+import { AstNode, HasAttributes } from "@djot/djot";
 import {
   DjockeyConfigResolved,
   DjockeyDoc,
   DjockeyPlugin,
+  DjockeyPluginNodeReservation,
   DjockeyRenderer,
 } from "../types.js";
 import { LogCollector } from "../utils/logUtils.js";
 import { DocTree } from "./doctree.js";
+import { getHasClass } from "../utils/djotUtils.js";
 
 export class DocSet {
   public tree: DocTree | null = null;
+
+  private reservations: DjockeyPluginNodeReservation[][];
 
   constructor(
     public config: DjockeyConfigResolved,
     public plugins: DjockeyPlugin[],
     public docs: DjockeyDoc[]
-  ) {}
+  ) {
+    this.reservations = this.plugins.map((p) =>
+      p.getNodeReservations ? p.getNodeReservations(this.config) : []
+    );
+  }
+
+  private getRelevantReservations(
+    pluginIndex: number
+  ): DjockeyPluginNodeReservation[] {
+    return this.reservations
+      .slice(0, pluginIndex)
+      .concat(
+        this.reservations.slice(pluginIndex + 1, this.reservations.length)
+      )
+      .flatMap((list) => list);
+  }
 
   public getDoc(relativePath: string): DjockeyDoc | null {
     return this.docs.find((d) => d.relativePath === relativePath) || null;
@@ -25,7 +45,8 @@ export class DocSet {
 
     const jobs = new Array<Promise<void>>();
     for (const doc of this.docs) {
-      for (const plugin of this.plugins) {
+      for (let i = 0; i < this.plugins.length; i++) {
+        const plugin = this.plugins[i];
         if (plugin.doAsyncWorkBetweenReadAndWrite) {
           jobs.push(plugin.doAsyncWorkBetweenReadAndWrite(doc));
         }
@@ -38,9 +59,17 @@ export class DocSet {
 
   private runPass(fn: "onPass_read" | "onPass_write") {
     for (const doc of this.docs) {
-      for (const plugin of this.plugins) {
+      for (let i = 0; i < this.plugins.length; i++) {
+        const plugin = this.plugins[i];
         if (plugin[fn]) {
-          plugin[fn](doc);
+          plugin[fn]({
+            doc,
+            getIsNodeReservedByAnotherPlugin: (node) => {
+              return this.getRelevantReservations(i).some((res) =>
+                res.match(node)
+              );
+            },
+          });
         }
       }
     }

--- a/src/plugins/autoTitlePlugin.ts
+++ b/src/plugins/autoTitlePlugin.ts
@@ -6,7 +6,8 @@ import { djotASTToText } from "../utils/djotUtils.js";
 export class AutoTitlePlugin implements DjockeyPlugin {
   name = "Auto Titler";
 
-  onPass_read(doc: DjockeyDoc) {
+  onPass_read(args: { doc: DjockeyDoc }) {
+    const { doc } = args;
     if (doc.frontMatter.title) {
       doc.title = doc.frontMatter.title as string;
       doc.titleAST = [{ tag: "str", text: doc.title }];

--- a/src/plugins/djotDemoPlugin.ts
+++ b/src/plugins/djotDemoPlugin.ts
@@ -1,15 +1,37 @@
-import { Div, HasAttributes, HasText, parse } from "@djot/djot";
-import { DjockeyDoc, DjockeyPlugin } from "../types.js";
+import { AstNode, Div, HasAttributes, HasText, parse } from "@djot/djot";
+import {
+  DjockeyConfigResolved,
+  DjockeyDoc,
+  DjockeyPlugin,
+  DjockeyPluginNodeReservation,
+} from "../types.js";
 import { applyFilter } from "../engine/djotFiltersPlus.js";
 import { getHasClass } from "../utils/djotUtils.js";
 
 export class DjotDemoPlugin implements DjockeyPlugin {
   name = "Djot Example";
 
-  onPass_write(doc: DjockeyDoc) {
+  getNodeReservations(
+    config: DjockeyConfigResolved
+  ): DjockeyPluginNodeReservation[] {
+    return [
+      {
+        match: (node) =>
+          node.tag == "code_block" &&
+          getHasClass(node as HasAttributes, "dj-djot-demo"),
+      },
+    ];
+  }
+
+  onPass_write(args: {
+    doc: DjockeyDoc;
+    getIsNodeReservedByAnotherPlugin: (node: AstNode) => boolean;
+  }) {
+    const { doc } = args;
     for (const djotDoc of Object.values(doc.docs)) {
       applyFilter(djotDoc, () => ({
-        code_block: (node: HasAttributes & HasText) => {
+        code_block: (node: AstNode & HasAttributes & HasText) => {
+          if (args.getIsNodeReservedByAnotherPlugin(node)) return;
           if (!getHasClass(node, "dj-djot-demo")) return;
 
           const renderedAST = parse(node.text);

--- a/src/plugins/gfmAlertsPlugin.ts
+++ b/src/plugins/gfmAlertsPlugin.ts
@@ -1,7 +1,7 @@
 import { DjockeyDoc, DjockeyPlugin } from "../types.js";
 import { applyFilter } from "../engine/djotFiltersPlus.js";
 import { djotASTToText, getHasClass } from "../utils/djotUtils.js";
-import { Block } from "@djot/djot";
+import { AstNode, Block } from "@djot/djot";
 
 // These happen to correspond to Djockey's 'aside' classes, so we're just going
 // to replace the 'div' tag with the 'aside' tag and remove the starting paragraph.
@@ -10,26 +10,43 @@ const GITHUB_ALERT_CLASSES = ["note", "tip", "important", "warning", "caution"];
 export class GFMAlertsPlugin implements DjockeyPlugin {
   name = "GitHub Flavored Markdown Alerts";
 
-  onPass_write(doc: DjockeyDoc) {
+  onPass_write(args: { doc: DjockeyDoc }) {
+    const { doc } = args;
     applyFilter(doc.docs.content, () => ({
       div: (node) => {
         for (const cls of GITHUB_ALERT_CLASSES) {
-          if (getHasClass(node, cls) && !node.attributes?.tag) {
-            const newNode = structuredClone(node);
+          if (!getHasClass(node, cls) && !node.attributes?.tag) continue;
+          const newNode = structuredClone(node);
+          newNode.attributes.tag = "aside";
 
-            const children = newNode.children || ([] as Block[]);
-            if (
-              !children.length ||
-              children[0].tag !== "p" ||
-              djotASTToText(children[0]).toLowerCase() !== cls
-            )
-              if (newNode.children && newNode.children.length)
-                newNode.attributes = { ...node.attributes, tag: "aside" };
-            newNode.children = newNode.children.slice(1);
-            return newNode;
-          }
+          if (!node.children) return newNode;
+
+          newNode.children = structuredClone(
+            getIsDivWithTitleInside(node.children[0], cls)
+              ? node.children.slice(1)
+              : node.children
+          );
+          return newNode;
         }
       },
     }));
   }
+}
+
+function getIsDivWithTitleInside(node: AstNode, expectedText: string): boolean {
+  console.log("Check", node);
+  if (node.tag !== "div") return false;
+  console.log(1);
+  if (node.children.length !== 1) return false;
+  console.log(2);
+  if (node.children[0].tag !== "para") return false;
+  console.log(3);
+  if (node.children[0].children.length !== 1) return false;
+  console.log(4);
+  if (node.children[0].children[0].tag !== "str") return false;
+  console.log(5);
+  if (node.children[0].children[0].text.toLowerCase() !== expectedText)
+    return false;
+  console.log(6);
+  return true;
 }

--- a/src/plugins/gfmAlertsPlugin.ts
+++ b/src/plugins/gfmAlertsPlugin.ts
@@ -15,7 +15,7 @@ export class GFMAlertsPlugin implements DjockeyPlugin {
     applyFilter(doc.docs.content, () => ({
       div: (node) => {
         for (const cls of GITHUB_ALERT_CLASSES) {
-          if (!getHasClass(node, cls) && !node.attributes?.tag) continue;
+          if (!getHasClass(node, cls) || !node.attributes?.tag) continue;
           const newNode = structuredClone(node);
           newNode.attributes.tag = "aside";
 
@@ -34,19 +34,15 @@ export class GFMAlertsPlugin implements DjockeyPlugin {
 }
 
 function getIsDivWithTitleInside(node: AstNode, expectedText: string): boolean {
-  console.log("Check", node);
   if (node.tag !== "div") return false;
-  console.log(1);
   if (node.children.length !== 1) return false;
-  console.log(2);
   if (node.children[0].tag !== "para") return false;
-  console.log(3);
   if (node.children[0].children.length !== 1) return false;
-  console.log(4);
   if (node.children[0].children[0].tag !== "str") return false;
-  console.log(5);
-  if (node.children[0].children[0].text.toLowerCase() !== expectedText)
+  if (
+    node.children[0].children[0].text.toLowerCase() !==
+    expectedText.toLowerCase()
+  )
     return false;
-  console.log(6);
   return true;
 }

--- a/src/plugins/indextermsPlugin.ts
+++ b/src/plugins/indextermsPlugin.ts
@@ -14,7 +14,8 @@ export class IndextermsPlugin implements DjockeyPlugin {
     Record<string, { docRelativePath: string; id: string }[]>
   > = {};
 
-  onPass_read(doc: DjockeyDoc) {
+  onPass_read(args: { doc: DjockeyDoc }) {
+    const { doc } = args;
     // During the read pass, find every node with an indexterm* attribute and
     // store it in indextermsByDoc.
 
@@ -53,7 +54,8 @@ export class IndextermsPlugin implements DjockeyPlugin {
     this.indextermsByDoc[doc.relativePath] = result;
   }
 
-  onPass_write(doc: DjockeyDoc) {
+  onPass_write(args: { doc: DjockeyDoc }) {
+    const { doc } = args;
     // During the write pass, look for the .index class on a div and replace it
     // with the actual index.
 

--- a/src/plugins/linkRewritingPlugin.ts
+++ b/src/plugins/linkRewritingPlugin.ts
@@ -49,7 +49,8 @@ export class LinkRewritingPlugin implements DjockeyPlugin {
     }
   }
 
-  onPass_read(doc: DjockeyDoc) {
+  onPass_read(args: { doc: DjockeyDoc }) {
+    const { doc } = args;
     const registerLinkTarget = (t: LinkTarget) => {
       t.aliases.forEach((alias) =>
         pushToListIfNotPresent(this._linkTargets, alias, t, (a, b) =>

--- a/src/plugins/mermaidPlugin.ts
+++ b/src/plugins/mermaidPlugin.ts
@@ -1,0 +1,25 @@
+import { AstNode, Heading } from "@djot/djot";
+import { applyFilter } from "../engine/djotFiltersPlus.js";
+import {
+  DjockeyConfigResolved,
+  DjockeyDoc,
+  DjockeyPlugin,
+  DjockeyPluginNodeReservation,
+} from "../types.js";
+import { djotASTToText } from "../utils/djotUtils.js";
+
+/**
+ * This is a stub plugin to preven SyntaxHighlightingPlugin from
+ * trying to highlight Mermaid code blocks.
+ */
+export class MermaidPlugin implements DjockeyPlugin {
+  name = "Mermaid";
+
+  getNodeReservations(
+    config: DjockeyConfigResolved
+  ): DjockeyPluginNodeReservation[] {
+    return [
+      { match: (node) => node.tag === "code_block" && node.lang === "mermaid" },
+    ];
+  }
+}

--- a/src/plugins/syntaxHighlighting.ts
+++ b/src/plugins/syntaxHighlighting.ts
@@ -66,7 +66,6 @@ export class SyntaxHighlightingPlugin implements DjockeyPlugin {
     }
 
     if (!lang) return defaultLanguage;
-    if (lang === "mermaid") throw new Error("MERMAID???");
     if (this.languages.has(lang)) return lang;
     if (lang === "plaintext") return "text";
 

--- a/src/plugins/syntaxHighlighting.ts
+++ b/src/plugins/syntaxHighlighting.ts
@@ -5,7 +5,14 @@ import {
   DjockeyRenderer,
 } from "../types.js";
 import { applyFilter } from "../engine/djotFiltersPlus.js";
-import { CodeBlock, Doc, RawBlock, RawInline, Verbatim } from "@djot/djot";
+import {
+  AstNode,
+  CodeBlock,
+  Doc,
+  RawBlock,
+  RawInline,
+  Verbatim,
+} from "@djot/djot";
 import {
   BundledLanguage,
   bundledLanguages,
@@ -59,8 +66,7 @@ export class SyntaxHighlightingPlugin implements DjockeyPlugin {
     }
 
     if (!lang) return defaultLanguage;
-    const forbidden = new Set(["mermaid"]);
-    if (forbidden.has(lang)) return null;
+    if (lang === "mermaid") throw new Error("MERMAID???");
     if (this.languages.has(lang)) return lang;
     if (lang === "plaintext") return "text";
 
@@ -100,9 +106,14 @@ export class SyntaxHighlightingPlugin implements DjockeyPlugin {
     }
   }
 
-  readDoc(doc: Doc, djockeyDoc: DjockeyDoc) {
+  readDoc(
+    doc: Doc,
+    djockeyDoc: DjockeyDoc,
+    getIsNodeReservedByAnotherPlugin: (node: AstNode) => boolean
+  ) {
     applyFilter(doc, () => ({
       code_block: (node: CodeBlock) => {
+        if (getIsNodeReservedByAnotherPlugin(node)) return;
         if (node.attributes?.hlRequestID) return; // Already scheduled
 
         const lang = this.getNodeLang(
@@ -124,6 +135,7 @@ export class SyntaxHighlightingPlugin implements DjockeyPlugin {
         return result;
       },
       verbatim: (node: Verbatim) => {
+        if (getIsNodeReservedByAnotherPlugin(node)) return;
         if (node.attributes?.hlRequestID) return; // Already scheduled
 
         const nodeClass = node.attributes?.class ?? "";
@@ -155,9 +167,13 @@ export class SyntaxHighlightingPlugin implements DjockeyPlugin {
     }));
   }
 
-  onPass_read(doc: DjockeyDoc) {
+  onPass_read(args: {
+    doc: DjockeyDoc;
+    getIsNodeReservedByAnotherPlugin: (node: AstNode) => boolean;
+  }) {
+    const { doc } = args;
     for (const djotDoc of Object.values(doc.docs)) {
-      this.readDoc(djotDoc, doc);
+      this.readDoc(djotDoc, doc, args.getIsNodeReservedByAnotherPlugin);
     }
   }
 
@@ -192,7 +208,6 @@ export class SyntaxHighlightingPlugin implements DjockeyPlugin {
           if (!hlRequestID) return;
           const newText = this.highlightResults[hlRequestID];
           if (!newText) {
-            args.logCollector.error("Unexpectedly can't find highlighted text");
             return;
           }
           const result: RawBlock = {
@@ -207,7 +222,6 @@ export class SyntaxHighlightingPlugin implements DjockeyPlugin {
           if (!hlRequestID) return;
           let newText = this.highlightResults[hlRequestID];
           if (!newText) {
-            args.logCollector.error("Unexpectedly can't find highlighted text");
             return;
           }
 

--- a/src/plugins/tabGroupPlugin.ts
+++ b/src/plugins/tabGroupPlugin.ts
@@ -11,7 +11,8 @@ import { Block, Div } from "@djot/djot";
 export class TabGroupPlugin implements DjockeyPlugin {
   name = "Tab Group";
 
-  onPass_read(doc: DjockeyDoc) {
+  onPass_read(args: { doc: DjockeyDoc }) {
+    const { doc } = args;
     let nextID = 0;
 
     applyFilter(doc.docs.content, () => ({

--- a/src/plugins/tableOfContentsPlugin.test.ts
+++ b/src/plugins/tableOfContentsPlugin.test.ts
@@ -33,8 +33,8 @@ test("Generates TOCEntry tree for one doc", async () => {
   };
 
   const plg = new TableOfContentsPlugin();
-  plg.onPass_read(doc);
-  plg.onPass_write(doc);
+  plg.onPass_read({ doc });
+  plg.onPass_write({ doc });
 
   const html = await renderHTML(doc.docs.toc);
 

--- a/src/plugins/tableOfContentsPlugin.ts
+++ b/src/plugins/tableOfContentsPlugin.ts
@@ -21,7 +21,8 @@ export class TableOfContentsPlugin implements DjockeyPlugin {
 
   topLevelTOCEntriesByDoc: Record<string, TOCEntry[]> = {};
 
-  onPass_read(doc: DjockeyDoc) {
+  onPass_read(args: { doc: DjockeyDoc }) {
+    const { doc } = args;
     // Always reset this array because this method may be run more than once
     this.topLevelTOCEntriesByDoc[doc.relativePath] = new Array<TOCEntry>();
 
@@ -82,7 +83,8 @@ export class TableOfContentsPlugin implements DjockeyPlugin {
     }));
   }
 
-  onPass_write(doc: DjockeyDoc) {
+  onPass_write(args: { doc: DjockeyDoc }) {
+    const { doc } = args;
     doc.docs.toc = {
       tag: "doc",
       references: {},

--- a/src/plugins/versionDirectives.ts
+++ b/src/plugins/versionDirectives.ts
@@ -46,7 +46,8 @@ export class VersionDirectivesPlugin implements DjockeyPlugin {
 
   constructor(public config: DjockeyConfig) {}
 
-  onPass_write(doc: DjockeyDoc) {
+  onPass_write(args: { doc: DjockeyDoc }) {
+    const { doc } = args;
     const projectVersion = this.config.project_info?.version;
     applyFilter(doc.docs.content, () => ({
       div: (node) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Doc, Inline } from "@djot/djot";
+import { AstNode, Doc, Inline } from "@djot/djot";
 import { Environment } from "nunjucks";
 import { LogCollector } from "./utils/logUtils.js";
 
@@ -106,20 +106,26 @@ export type DjockeyRenderer = {
   }) => string;
 };
 
-/**
- * Notes:
- * - Passes should be idempotent so they can be run multiple times
- */
 export type DjockeyPlugin = {
   name: string;
 
+  getNodeReservations?: (
+    config: DjockeyConfigResolved
+  ) => DjockeyPluginNodeReservation[];
+
   setup?: (args: { logCollector: LogCollector }) => Promise<void>;
 
-  onPass_read?: (doc: DjockeyDoc) => void;
+  onPass_read?: (args: {
+    doc: DjockeyDoc;
+    getIsNodeReservedByAnotherPlugin: (node: AstNode) => boolean;
+  }) => void;
 
   doAsyncWorkBetweenReadAndWrite?: (doc: DjockeyDoc) => Promise<void>;
 
-  onPass_write?: (doc: DjockeyDoc) => void;
+  onPass_write?: (args: {
+    doc: DjockeyDoc;
+    getIsNodeReservedByAnotherPlugin: (node: AstNode) => boolean;
+  }) => void;
 
   onPrepareForRender?: (args: {
     doc: DjockeyDoc;
@@ -127,6 +133,10 @@ export type DjockeyPlugin = {
     config: DjockeyConfigResolved;
     logCollector: LogCollector;
   }) => void;
+};
+
+export type DjockeyPluginNodeReservation = {
+  match: (node: AstNode) => Boolean;
 };
 
 export type DjockeyPluginModule = {

--- a/templates/html/static/dj-style.css
+++ b/templates/html/static/dj-style.css
@@ -259,8 +259,11 @@ nav h6 {
 
 #dj-mobile-menu::backdrop {
   background-color: rgba(0, 0, 0, 0.15);
+  /* blur has awful perf in Chrome */
+  /*
   backdrop-filter: blur(1px);
   -webkit-backdrop-filter: blur(1px);
+  */
 }
 
 /* COMPONENTS */


### PR DESCRIPTION
Fix #24.

The primary use case is to prevent SyntaxHighlighting from touching Mermaid nodes, without needing to know exactly what Mermaid is.