### PR TITLE
Link resolution is more predictable and less overall stupid

### DIFF
--- a/docs/out/gfm/features/typedoc.md
+++ b/docs/out/gfm/features/typedoc.md
@@ -32,7 +32,7 @@ Djockey can integrate with [TypeDoc](https://typedoc.org) to create an
 integrated documentation experience that combines the authoring power of
 Djockey with rich API references. For example, here in the Djockey docs,
 we can type `[](:ts:DjockeyPlugin)` and get
-[DjockeyPlugin](../api//interfaces/DjockeyPlugin.html).
+[DjockeyPlugin](../api/interfaces/DjockeyPlugin.html).
 
 The core concept is to render TypeDoc normally inside your docs
 directory, treat its output as static files, and then create convenient

--- a/docs/out/gfm/typescript_link_mapping.json
+++ b/docs/out/gfm/typescript_link_mapping.json
@@ -107,6 +107,16 @@
       "defaultLabel": "label"
     },
     {
+      "linkDestination": "LogCollector.hasWarningsOrErrors",
+      "relativeURL": "classes/LogCollector.html#hasWarningsOrErrors",
+      "defaultLabel": "hasWarningsOrErrors"
+    },
+    {
+      "linkDestination": "hasWarningsOrErrors",
+      "relativeURL": "classes/LogCollector.html#hasWarningsOrErrors",
+      "defaultLabel": "hasWarningsOrErrors"
+    },
+    {
       "linkDestination": "LogCollector.debug",
       "relativeURL": "classes/LogCollector.html#debug",
       "defaultLabel": "debug"
@@ -145,6 +155,16 @@
       "linkDestination": "fail",
       "relativeURL": "classes/LogCollector.html#fail",
       "defaultLabel": "fail"
+    },
+    {
+      "linkDestination": "LogCollector.getChild",
+      "relativeURL": "classes/LogCollector.html#getChild",
+      "defaultLabel": "getChild"
+    },
+    {
+      "linkDestination": "getChild",
+      "relativeURL": "classes/LogCollector.html#getChild",
+      "defaultLabel": "getChild"
     },
     {
       "linkDestination": "LogCollector.info",
@@ -432,16 +452,6 @@
       "defaultLabel": "DjockeyDoc"
     },
     {
-      "linkDestination": "DjockeyDoc.absolutePath",
-      "relativeURL": "interfaces/DjockeyDoc.html#absolutePath",
-      "defaultLabel": "absolutePath"
-    },
-    {
-      "linkDestination": "absolutePath",
-      "relativeURL": "interfaces/DjockeyDoc.html#absolutePath",
-      "defaultLabel": "absolutePath"
-    },
-    {
       "linkDestination": "DjockeyDoc.data",
       "relativeURL": "interfaces/DjockeyDoc.html#data",
       "defaultLabel": "data"
@@ -482,6 +492,16 @@
       "defaultLabel": "frontMatter"
     },
     {
+      "linkDestination": "DjockeyDoc.fsPath",
+      "relativeURL": "interfaces/DjockeyDoc.html#fsPath",
+      "defaultLabel": "fsPath"
+    },
+    {
+      "linkDestination": "fsPath",
+      "relativeURL": "interfaces/DjockeyDoc.html#fsPath",
+      "defaultLabel": "fsPath"
+    },
+    {
       "linkDestination": "DjockeyDoc.neighbors",
       "relativeURL": "interfaces/DjockeyDoc.html#neighbors",
       "defaultLabel": "neighbors"
@@ -502,14 +522,14 @@
       "defaultLabel": "originalExtension"
     },
     {
-      "linkDestination": "DjockeyDoc.relativePath",
-      "relativeURL": "interfaces/DjockeyDoc.html#relativePath",
-      "defaultLabel": "relativePath"
+      "linkDestination": "DjockeyDoc.refPath",
+      "relativeURL": "interfaces/DjockeyDoc.html#refPath",
+      "defaultLabel": "refPath"
     },
     {
-      "linkDestination": "relativePath",
-      "relativeURL": "interfaces/DjockeyDoc.html#relativePath",
-      "defaultLabel": "relativePath"
+      "linkDestination": "refPath",
+      "relativeURL": "interfaces/DjockeyDoc.html#refPath",
+      "defaultLabel": "refPath"
     },
     {
       "linkDestination": "DjockeyDoc.title",
@@ -627,6 +647,16 @@
       "defaultLabel": "getNodeReservations"
     },
     {
+      "linkDestination": "DjockeyPlugin.getStaticFiles",
+      "relativeURL": "interfaces/DjockeyPlugin.html#getStaticFiles",
+      "defaultLabel": "getStaticFiles"
+    },
+    {
+      "linkDestination": "getStaticFiles",
+      "relativeURL": "interfaces/DjockeyPlugin.html#getStaticFiles",
+      "defaultLabel": "getStaticFiles"
+    },
+    {
       "linkDestination": "DjockeyPlugin.name",
       "relativeURL": "interfaces/DjockeyPlugin.html#name",
       "defaultLabel": "name"
@@ -705,6 +735,31 @@
       "linkDestination": "match",
       "relativeURL": "interfaces/DjockeyPluginNodeReservation.html#match",
       "defaultLabel": "match"
+    },
+    {
+      "linkDestination": "DjockeyStaticFileFromPlugin",
+      "relativeURL": "interfaces/DjockeyStaticFileFromPlugin.html",
+      "defaultLabel": "DjockeyStaticFileFromPlugin"
+    },
+    {
+      "linkDestination": "DjockeyStaticFileFromPlugin.contents",
+      "relativeURL": "interfaces/DjockeyStaticFileFromPlugin.html#contents",
+      "defaultLabel": "contents"
+    },
+    {
+      "linkDestination": "contents",
+      "relativeURL": "interfaces/DjockeyStaticFileFromPlugin.html#contents",
+      "defaultLabel": "contents"
+    },
+    {
+      "linkDestination": "DjockeyStaticFileFromPlugin.path",
+      "relativeURL": "interfaces/DjockeyStaticFileFromPlugin.html#path",
+      "defaultLabel": "path"
+    },
+    {
+      "linkDestination": "path",
+      "relativeURL": "interfaces/DjockeyStaticFileFromPlugin.html#path",
+      "defaultLabel": "path"
     },
     {
       "linkDestination": "LinkMappingConfig",

--- a/docs/src/typescript_link_mapping.json
+++ b/docs/src/typescript_link_mapping.json
@@ -107,6 +107,16 @@
       "defaultLabel": "label"
     },
     {
+      "linkDestination": "LogCollector.hasWarningsOrErrors",
+      "relativeURL": "classes/LogCollector.html#hasWarningsOrErrors",
+      "defaultLabel": "hasWarningsOrErrors"
+    },
+    {
+      "linkDestination": "hasWarningsOrErrors",
+      "relativeURL": "classes/LogCollector.html#hasWarningsOrErrors",
+      "defaultLabel": "hasWarningsOrErrors"
+    },
+    {
       "linkDestination": "LogCollector.debug",
       "relativeURL": "classes/LogCollector.html#debug",
       "defaultLabel": "debug"
@@ -145,6 +155,16 @@
       "linkDestination": "fail",
       "relativeURL": "classes/LogCollector.html#fail",
       "defaultLabel": "fail"
+    },
+    {
+      "linkDestination": "LogCollector.getChild",
+      "relativeURL": "classes/LogCollector.html#getChild",
+      "defaultLabel": "getChild"
+    },
+    {
+      "linkDestination": "getChild",
+      "relativeURL": "classes/LogCollector.html#getChild",
+      "defaultLabel": "getChild"
     },
     {
       "linkDestination": "LogCollector.info",
@@ -432,16 +452,6 @@
       "defaultLabel": "DjockeyDoc"
     },
     {
-      "linkDestination": "DjockeyDoc.absolutePath",
-      "relativeURL": "interfaces/DjockeyDoc.html#absolutePath",
-      "defaultLabel": "absolutePath"
-    },
-    {
-      "linkDestination": "absolutePath",
-      "relativeURL": "interfaces/DjockeyDoc.html#absolutePath",
-      "defaultLabel": "absolutePath"
-    },
-    {
       "linkDestination": "DjockeyDoc.data",
       "relativeURL": "interfaces/DjockeyDoc.html#data",
       "defaultLabel": "data"
@@ -482,6 +492,16 @@
       "defaultLabel": "frontMatter"
     },
     {
+      "linkDestination": "DjockeyDoc.fsPath",
+      "relativeURL": "interfaces/DjockeyDoc.html#fsPath",
+      "defaultLabel": "fsPath"
+    },
+    {
+      "linkDestination": "fsPath",
+      "relativeURL": "interfaces/DjockeyDoc.html#fsPath",
+      "defaultLabel": "fsPath"
+    },
+    {
       "linkDestination": "DjockeyDoc.neighbors",
       "relativeURL": "interfaces/DjockeyDoc.html#neighbors",
       "defaultLabel": "neighbors"
@@ -502,14 +522,14 @@
       "defaultLabel": "originalExtension"
     },
     {
-      "linkDestination": "DjockeyDoc.relativePath",
-      "relativeURL": "interfaces/DjockeyDoc.html#relativePath",
-      "defaultLabel": "relativePath"
+      "linkDestination": "DjockeyDoc.refPath",
+      "relativeURL": "interfaces/DjockeyDoc.html#refPath",
+      "defaultLabel": "refPath"
     },
     {
-      "linkDestination": "relativePath",
-      "relativeURL": "interfaces/DjockeyDoc.html#relativePath",
-      "defaultLabel": "relativePath"
+      "linkDestination": "refPath",
+      "relativeURL": "interfaces/DjockeyDoc.html#refPath",
+      "defaultLabel": "refPath"
     },
     {
       "linkDestination": "DjockeyDoc.title",
@@ -627,6 +647,16 @@
       "defaultLabel": "getNodeReservations"
     },
     {
+      "linkDestination": "DjockeyPlugin.getStaticFiles",
+      "relativeURL": "interfaces/DjockeyPlugin.html#getStaticFiles",
+      "defaultLabel": "getStaticFiles"
+    },
+    {
+      "linkDestination": "getStaticFiles",
+      "relativeURL": "interfaces/DjockeyPlugin.html#getStaticFiles",
+      "defaultLabel": "getStaticFiles"
+    },
+    {
       "linkDestination": "DjockeyPlugin.name",
       "relativeURL": "interfaces/DjockeyPlugin.html#name",
       "defaultLabel": "name"
@@ -705,6 +735,31 @@
       "linkDestination": "match",
       "relativeURL": "interfaces/DjockeyPluginNodeReservation.html#match",
       "defaultLabel": "match"
+    },
+    {
+      "linkDestination": "DjockeyStaticFileFromPlugin",
+      "relativeURL": "interfaces/DjockeyStaticFileFromPlugin.html",
+      "defaultLabel": "DjockeyStaticFileFromPlugin"
+    },
+    {
+      "linkDestination": "DjockeyStaticFileFromPlugin.contents",
+      "relativeURL": "interfaces/DjockeyStaticFileFromPlugin.html#contents",
+      "defaultLabel": "contents"
+    },
+    {
+      "linkDestination": "contents",
+      "relativeURL": "interfaces/DjockeyStaticFileFromPlugin.html#contents",
+      "defaultLabel": "contents"
+    },
+    {
+      "linkDestination": "DjockeyStaticFileFromPlugin.path",
+      "relativeURL": "interfaces/DjockeyStaticFileFromPlugin.html#path",
+      "defaultLabel": "path"
+    },
+    {
+      "linkDestination": "path",
+      "relativeURL": "interfaces/DjockeyStaticFileFromPlugin.html#path",
+      "defaultLabel": "path"
     },
     {
       "linkDestination": "LinkMappingConfig",

--- a/src/plugins/linkRewritingPlugin.test.ts
+++ b/src/plugins/linkRewritingPlugin.test.ts
@@ -1,7 +1,47 @@
-import { resolveRelativePath } from "./linkRewritingPlugin.js";
+import { Doc } from "@djot/djot";
+import {
+  MappableLinkTarget,
+  resolveRelativeRefPath,
+} from "./linkRewritingPlugin.js";
 
 test("Resolves explicit relative links", () => {
-  expect(resolveRelativePath("a/b/c.txt", "./d.txt")).toEqual("/a/b/d.txt");
-  expect(resolveRelativePath("a/b/c.txt", "./../d.txt")).toEqual("/a/d.txt");
-  expect(resolveRelativePath("a/b/c.txt", "../d.txt")).toEqual("/a/d.txt");
+  expect(resolveRelativeRefPath("a/b/c.txt", "./d.txt")).toEqual("/a/b/d.txt");
+  expect(resolveRelativeRefPath("a/b/c.txt", "./../d.txt")).toEqual("/a/d.txt");
+  expect(resolveRelativeRefPath("a/b/c.txt", "../d.txt")).toEqual("/a/d.txt");
+});
+
+test("MappableLinkTarget has expected values", () => {
+  const stubDoc: Doc = {
+    tag: "doc",
+    references: {},
+    autoReferences: {},
+    footnotes: {},
+    children: [],
+  };
+  const t = new MappableLinkTarget(
+    {
+      docs: {
+        content: stubDoc,
+      },
+      title: "The Doc",
+      titleAST: [],
+      originalExtension: ".djot",
+      fsPath: "/fsroot/input/subdir/the_doc.djot",
+      refPath: "subdir/the_doc",
+      filename: "the_doc",
+      frontMatter: {},
+      data: {},
+    },
+    "the-hash"
+  );
+
+  expect(t.aliases).toEqual([
+    "#the-hash",
+    "the_doc#the-hash",
+    "the_doc.djot#the-hash",
+    "subdir/the_doc#the-hash",
+    "subdir/the_doc.djot#the-hash",
+    "/subdir/the_doc#the-hash",
+    "/subdir/the_doc.djot#the-hash",
+  ]);
 });

--- a/src/plugins/linkRewritingPlugin.ts
+++ b/src/plugins/linkRewritingPlugin.ts
@@ -197,9 +197,14 @@ export function resolveDirectLink(
   renderArgs: Parameters<MappableLinkTarget["renderDestination"]>[0]
 ): string | null {
   const resolvedRelativePath = resolveRelativeRefPath(sourceRefPath, link.path);
-  const maybeLinkTargets = linkTargets[resolvedRelativePath];
-  if (maybeLinkTargets) {
-    return maybeLinkTargets[0].renderDestination(renderArgs);
+  for (const k of [
+    maybeAddHash(resolvedRelativePath, link.hash),
+    resolvedRelativePath,
+  ]) {
+    const maybeLinkTargets = linkTargets[k];
+    if (maybeLinkTargets) {
+      return maybeLinkTargets[0].renderDestination(renderArgs);
+    }
   }
 
   // Look for a static file


### PR DESCRIPTION
Fix #44

- Links with no prefix (`/` or `./` or `../`) are first treated as "direct" relative links before looking at the link alias system. This is the main improvement.
- Reorganize link rewriting code to be more flexible and testable
- I'm sure I fixed other minor bugs that no one ever found